### PR TITLE
Enable all polars dtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "polars-lazy",
  "polars-ops",
  "polars-parquet",
+ "polars-plan",
  "polars-sql",
  "polars-time",
  "polars-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ polars = { version = "0.51.0", features = [
     "csv",
     "parquet",
     "json",
-    "dtype-datetime",
-    "dtype-date",
+    "dtype-full",
 ] }
 
 # Excel file processing


### PR DESCRIPTION
Parquet files containing columns with unsupported dtypes will crash the program. Using the `dtype-full` feature makes sure that any parquet file can be read. This resolves issue #1 